### PR TITLE
Added missing `ignoreCancelled` tags

### DIFF
--- a/src/main/java/com/civclassic/pvptweaks/tweaks/PotionTweaks.java
+++ b/src/main/java/com/civclassic/pvptweaks/tweaks/PotionTweaks.java
@@ -47,7 +47,7 @@ public class PotionTweaks extends Tweak {
 		}
 	}
 	
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onPotionSplash(PotionSplashEvent event) {
 		PotionEffect effect = event.getEntity().getEffects().iterator().next();
 		if(effect == null) return;
@@ -69,7 +69,7 @@ public class PotionTweaks extends Tweak {
 		}
 	}
 	
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onPlayerItemConsume(PlayerItemConsumeEvent event) {
 		Player player = event.getPlayer();
 		ItemStack item = event.getItem();


### PR DESCRIPTION
These *must* be added to event handlers which directly cause things to happen. For example, `onPotionSplash` previously didn't have `(ignoreCancelled = true)`, so it gave splash status effects to players hit by potions thrown by Exile Pearled players, even though Exile Pearl cancels the `PotionSplashEvent` specifically to prevent this.

The other handlers in this file are OK because they don't modify the player/world, only the event itself. This means that these handlers only do anything if the event is actually carried out anyway.