### PR TITLE
Fix regen tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/target/
+.classpath
+.settings/**
+.project
+.idea
+*.iml

--- a/src/main/java/com/civclassic/pvptweaks/tweaks/GeneralTweaks.java
+++ b/src/main/java/com/civclassic/pvptweaks/tweaks/GeneralTweaks.java
@@ -1,48 +1,42 @@
 package com.civclassic.pvptweaks.tweaks;
 
-import java.util.UUID;
-
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.entity.EntityRegainHealthEvent;
-import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
+import org.bukkit.Bukkit;
 
 import com.civclassic.pvptweaks.PvPTweaks;
 import com.civclassic.pvptweaks.Tweak;
 
-import vg.civcraft.mc.civmodcore.util.cooldowns.ICoolDownHandler;
-import vg.civcraft.mc.civmodcore.util.cooldowns.MilliSecCoolDownHandler;
-
 public class GeneralTweaks extends Tweak {
 
 	private double healthRegen;
-	private ICoolDownHandler<UUID> regenCds;
+	private float exhaustionCost;
+	private Integer bukkitTaskId;
 	
 	public GeneralTweaks(PvPTweaks plugin, ConfigurationSection config) {
 		super(plugin, config);
 	}
 
-	@EventHandler
-	public void onEntityRegainHealth(EntityRegainHealthEvent event) {
-		if(event.getRegainReason() != RegainReason.REGEN || event.getRegainReason() != RegainReason.SATIATED
-				|| event.getEntityType() != EntityType.PLAYER) {
-			return;
-		}
-		Player player = (Player) event.getEntity();
-		if(regenCds.onCoolDown(player.getUniqueId())) {
-			event.setCancelled(true);
-		} else {
-			event.setAmount(healthRegen);
-			regenCds.putOnCoolDown(player.getUniqueId());
-		}
-	}
-	
 	@Override
 	public void loadConfig(ConfigurationSection config) {
 		healthRegen = config.getDouble("healthRegen");
-		regenCds = new MilliSecCoolDownHandler<UUID>(config.getLong("regenDelay"));
+		exhaustionCost = (float) config.getDouble("exhaustionCost");
+		long regenFrequency = config.getLong("regenDelay");
+		if(bukkitTaskId != null){
+			// Cancel old task
+			Bukkit.getScheduler().cancelTask(bukkitTaskId);
+		}
+		bukkitTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin(), new Runnable() {
+			@Override
+			public void run() {
+				Bukkit.getOnlinePlayers().forEach(p -> {
+					p.getWorld().setGameRuleValue("naturalRegeneration","false");
+					if(p.getFoodLevel() >= 18 && p.getHealth() < p.getMaxHealth()){
+						p.setHealth(Math.min(p.getMaxHealth(),p.getHealth() + healthRegen));
+						p.setExhaustion(p.getExhaustion() + exhaustionCost);
+					}
+				});
+			}
+}, 1L, regenFrequency);
 	}
 
 	@Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,8 @@ tweaks:
     - FROST_WALKER
   GeneralTweaks:
     healthRegen: 1.0
-    regenDelay: 4000
+    exhaustionCost: 6.0
+    regenDelay: 100
   PearlTweaks:
     #cooldown in ticks, 300 = 15 seconds
     cooldown: 300


### PR DESCRIPTION
**Note**: This changes `regenDelay` to be in terms of ticks, so you *must* update the config to remain compatible. You should also add an exhaustion cost to indicate how much exhaustion it should take to heal over one interval. Vanilla does 6 exhaustion per half hunger thingy.