### PR TITLE
Add Projectile Tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/target/
+.classpath
+.settings/**
+.project
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
         	<groupId>vg.civcraft.mc.civmodcore</groupId>
         	<artifactId>CivModCore</artifactId>
-        	<version>1.6.0</version>
+        	<version>1.6.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/civclassic/pvptweaks/tweaks/GeneralTweaks.java
+++ b/src/main/java/com/civclassic/pvptweaks/tweaks/GeneralTweaks.java
@@ -1,48 +1,42 @@
 package com.civclassic.pvptweaks.tweaks;
 
-import java.util.UUID;
-
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.entity.EntityRegainHealthEvent;
-import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
+import org.bukkit.Bukkit;
 
 import com.civclassic.pvptweaks.PvPTweaks;
 import com.civclassic.pvptweaks.Tweak;
 
-import vg.civcraft.mc.civmodcore.util.cooldowns.ICoolDownHandler;
-import vg.civcraft.mc.civmodcore.util.cooldowns.MilliSecCoolDownHandler;
-
 public class GeneralTweaks extends Tweak {
 
 	private double healthRegen;
-	private ICoolDownHandler<UUID> regenCds;
+	private float exhaustionCost;
+	private Integer bukkitTaskId;
 	
 	public GeneralTweaks(PvPTweaks plugin, ConfigurationSection config) {
 		super(plugin, config);
 	}
 
-	@EventHandler
-	public void onEntityRegainHealth(EntityRegainHealthEvent event) {
-		if(event.getRegainReason() != RegainReason.REGEN || event.getRegainReason() != RegainReason.SATIATED
-				|| event.getEntityType() != EntityType.PLAYER) {
-			return;
-		}
-		Player player = (Player) event.getEntity();
-		if(regenCds.onCoolDown(player.getUniqueId())) {
-			event.setCancelled(true);
-		} else {
-			event.setAmount(healthRegen);
-			regenCds.putOnCoolDown(player.getUniqueId());
-		}
-	}
-	
 	@Override
 	public void loadConfig(ConfigurationSection config) {
 		healthRegen = config.getDouble("healthRegen");
-		regenCds = new MilliSecCoolDownHandler<UUID>(config.getLong("regenDelay"));
+		exhaustionCost = (float) config.getDouble("exhaustionCost");
+		long regenFrequency = config.getLong("regenDelay");
+		if(bukkitTaskId != null){
+			// Cancel old task
+			Bukkit.getScheduler().cancelTask(bukkitTaskId);
+		}
+		bukkitTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin(), new Runnable() {
+			@Override
+			public void run() {
+				Bukkit.getOnlinePlayers().forEach(p -> {
+					p.getWorld().setGameRuleValue("naturalRegeneration","false");
+					if(p.getFoodLevel() >= 18 && p.getHealth() < p.getMaxHealth()){
+						p.setHealth(Math.min(p.getMaxHealth(),p.getHealth() + healthRegen));
+						p.setExhaustion(p.getExhaustion() + exhaustionCost);
+					}
+				});
+			}
+}, 1L, regenFrequency);
 	}
 
 	@Override

--- a/src/main/java/com/civclassic/pvptweaks/tweaks/GeneralTweaks.java
+++ b/src/main/java/com/civclassic/pvptweaks/tweaks/GeneralTweaks.java
@@ -30,7 +30,9 @@ public class GeneralTweaks extends Tweak {
 		Bukkit.getServer().getWorlds().forEach(w -> w.setGameRuleValue("naturalRegeneration","false"));
 		bukkitTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin(), () -> {
 			Bukkit.getOnlinePlayers().forEach(p -> {
-				if(p.getFoodLevel() >= 18 && p.getHealth() < p.getMaxHealth()){
+				// If they are healed with health <= 0, they turn sideways and red
+				// and can still walk around.
+				if(p.getFoodLevel() >= 18 && p.getHealth() < p.getMaxHealth() && !(p.getHealth() <= 0)){
 					p.setHealth(Math.min(p.getMaxHealth(),p.getHealth() + healthRegen));
 					p.setExhaustion(p.getExhaustion() + exhaustionCost);
 				}

--- a/src/main/java/com/civclassic/pvptweaks/tweaks/GeneralTweaks.java
+++ b/src/main/java/com/civclassic/pvptweaks/tweaks/GeneralTweaks.java
@@ -10,6 +10,7 @@ public class GeneralTweaks extends Tweak {
 
 	private double healthRegen;
 	private float exhaustionCost;
+	private long regenFrequency;
 	private Integer bukkitTaskId;
 	
 	public GeneralTweaks(PvPTweaks plugin, ConfigurationSection config) {
@@ -20,29 +21,29 @@ public class GeneralTweaks extends Tweak {
 	public void loadConfig(ConfigurationSection config) {
 		healthRegen = config.getDouble("healthRegen");
 		exhaustionCost = (float) config.getDouble("exhaustionCost");
-		long regenFrequency = config.getLong("regenDelay");
+		regenFrequency = config.getLong("regenDelay");
 		if(bukkitTaskId != null){
 			// Cancel old task
 			Bukkit.getScheduler().cancelTask(bukkitTaskId);
 		}
-		bukkitTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin(), new Runnable() {
-			@Override
-			public void run() {
-				Bukkit.getOnlinePlayers().forEach(p -> {
-					p.getWorld().setGameRuleValue("naturalRegeneration","false");
-					if(p.getFoodLevel() >= 18 && p.getHealth() < p.getMaxHealth()){
-						p.setHealth(Math.min(p.getMaxHealth(),p.getHealth() + healthRegen));
-						p.setExhaustion(p.getExhaustion() + exhaustionCost);
-					}
-				});
-			}
-}, 1L, regenFrequency);
+		// Disable natural regen completely
+		Bukkit.getServer().getWorlds().forEach(w -> w.setGameRuleValue("naturalRegeneration","false"));
+		bukkitTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin(), () -> {
+			Bukkit.getOnlinePlayers().forEach(p -> {
+				if(p.getFoodLevel() >= 18 && p.getHealth() < p.getMaxHealth()){
+					p.setHealth(Math.min(p.getMaxHealth(),p.getHealth() + healthRegen));
+					p.setExhaustion(p.getExhaustion() + exhaustionCost);
+				}
+			});
+		}, 1L, regenFrequency);
 	}
 
 	@Override
 	protected String status() {
 		StringBuilder status = new StringBuilder();
 		status.append("  healthRegen: ").append(healthRegen);
+		status.append("  regenDelay: ").append(regenFrequency);
+		status.append("  exhaustionCost: ").append(exhaustionCost);
 		return status.toString();
 	}
 }

--- a/src/main/java/com/civclassic/pvptweaks/tweaks/ProjectileTweaks.java
+++ b/src/main/java/com/civclassic/pvptweaks/tweaks/ProjectileTweaks.java
@@ -1,0 +1,58 @@
+package com.civclassic.pvptweaks.tweaks;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.EnderPearl;
+import org.bukkit.entity.ThrownPotion;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+
+import com.civclassic.pvptweaks.PvPTweaks;
+import com.civclassic.pvptweaks.Tweak;
+
+public class ProjectileTweaks extends Tweak {
+	private boolean tweakPearls;
+	private boolean tweakPots;
+	private boolean tweakAll;
+
+	public ProjectileTweaks(PvPTweaks plugin, ConfigurationSection config) {
+		super(plugin, config);
+		tweakPearls = false;
+		tweakPots = false;
+		tweakAll = false;
+	}
+
+	@EventHandler(ignoreCancelled=true)
+	public void onThrowProjectile(ProjectileLaunchEvent e) {
+		if(!(e.getEntity().getShooter() instanceof Player) || (!tweakAll
+		  && ((!tweakPearls && e.getEntity() instanceof EnderPearl)
+		  || (!tweakPots && e.getEntity() instanceof ThrownPotion)))){
+			return;
+		}
+		Player p = (Player) e.getEntity().getShooter();
+		e.getEntity().setVelocity(e.getEntity().getVelocity().subtract(p.getVelocity()));
+	}
+
+	@Override
+	public void loadConfig(ConfigurationSection config) {
+		tweakPearls = config.getBoolean("tweakPearls");
+		tweakPots = config.getBoolean("tweakPots");
+		tweakAll = config.getBoolean("tweakAll");
+	}
+
+	@Override
+	public String status() {
+		StringBuilder status = new StringBuilder();
+		status.append("  Enabled projectiles: \n");
+		if(tweakPearls){
+			status.append("    ").append("Pearls").append("\n");
+		}
+		if(tweakPots){
+			status.append("    ").append("Potions").append("\n");
+		}
+		if(tweakAll){
+			status.append("    ").append("All").append("\n");
+		}
+		return status.toString();
+	}
+}

--- a/src/main/java/com/civclassic/pvptweaks/tweaks/ProtectionTweaks.java
+++ b/src/main/java/com/civclassic/pvptweaks/tweaks/ProtectionTweaks.java
@@ -148,6 +148,9 @@ public class ProtectionTweaks extends Tweak {
 		
 		int epf = 0;
 		for(ItemStack armor : inv.getArmorContents()) {
+			if(armor == null){
+				continue;
+			}
 			int level = armor.getEnchantmentLevel(Enchantment.PROTECTION_ENVIRONMENTAL);
 			if(level == 4) level = 5;
 			epf += level;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,8 +5,8 @@ tweaks:
     - FROST_WALKER
   GeneralTweaks:
     healthRegen: 1.0
-    exhaustionCost: 6.0
     regenDelay: 100
+    exhaustionCost: 6.0
   PearlTweaks:
     #cooldown in ticks, 300 = 15 seconds
     cooldown: 300

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,8 @@ tweaks:
     - FROST_WALKER
   GeneralTweaks:
     healthRegen: 1.0
-    regenDelay: 4000
+    exhaustionCost: 6.0
+    regenDelay: 100
   PearlTweaks:
     #cooldown in ticks, 300 = 15 seconds
     cooldown: 300

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -43,3 +43,7 @@ tweaks:
     prot_mitigation: 7
     prot_scale: 0.5
     linear_prot: true
+  ProjectileTweaks:
+    tweakPearls: true
+    tweakPots: true
+    tweakAll: false


### PR DESCRIPTION
This removes the (mis)feature where player velocity affects potion and pearl velocity. This matters for PvP because you could get semi-randomly knocked off your pots if you were unlucky with lag, or have your pearls fly somewhere random if you mis-compensate for lag (which is time varying, so this is impossible to do in practice).