### PR TITLE
Projectile Tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/target/
+.classpath
+.settings/**
+.project
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
         	<groupId>vg.civcraft.mc.civmodcore</groupId>
         	<artifactId>CivModCore</artifactId>
-        	<version>1.6.0</version>
+        	<version>1.6.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/civclassic/pvptweaks/tweaks/ProjectileTweaks.java
+++ b/src/main/java/com/civclassic/pvptweaks/tweaks/ProjectileTweaks.java
@@ -1,0 +1,58 @@
+package com.civclassic.pvptweaks.tweaks;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.EnderPearl;
+import org.bukkit.entity.ThrownPotion;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+
+import com.civclassic.pvptweaks.PvPTweaks;
+import com.civclassic.pvptweaks.Tweak;
+
+public class ProjectileTweaks extends Tweak {
+	private boolean tweakPearls;
+	private boolean tweakPots;
+	private boolean tweakAll;
+
+	public ProjectileTweaks(PvPTweaks plugin, ConfigurationSection config) {
+		super(plugin, config);
+		tweakPearls = false;
+		tweakPots = false;
+		tweakAll = false;
+	}
+
+	@EventHandler(ignoreCancelled=true)
+	public void onThrowProjectile(ProjectileLaunchEvent e) {
+		if(!(e.getEntity().getShooter() instanceof Player) || (!tweakAll
+		  && ((!tweakPearls && e.getEntity() instanceof EnderPearl)
+		  || (!tweakPots && e.getEntity() instanceof ThrownPotion)))){
+			return;
+		}
+		Player p = (Player) e.getEntity().getShooter();
+		e.getEntity().setVelocity(e.getEntity().getVelocity().subtract(p.getVelocity()));
+	}
+
+	@Override
+	public void loadConfig(ConfigurationSection config) {
+		tweakPearls = config.getBoolean("tweakPearls");
+		tweakPots = config.getBoolean("tweakPots");
+		tweakAll = config.getBoolean("tweakAll");
+	}
+
+	@Override
+	public String status() {
+		StringBuilder status = new StringBuilder();
+		status.append("  Enabled projectiles: \n");
+		if(tweakPearls){
+			status.append("    ").append("Pearls").append("\n");
+		}
+		if(tweakPots){
+			status.append("    ").append("Potions").append("\n");
+		}
+		if(tweakAll){
+			status.append("    ").append("All").append("\n");
+		}
+		return status.toString();
+	}
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -42,3 +42,7 @@ tweaks:
     prot_mitigation: 7
     prot_scale: 0.5
     linear_prot: true
+  ProjectileTweaks:
+    tweakPearls: true
+    tweakPots: true
+    tweakAll: false


### PR DESCRIPTION
This removes the (mis)feature where player velocity affects potion and pearl velocity. This matters for PvP because you could get semi-randomly knocked off your pots if you were unlucky with lag, or have your pearls fly somewhere random if you mis-compensate for lag (which is time varying, so this is impossible to do in practice).

This is the better version of #8.